### PR TITLE
fix: remove printing 'mode' on copy

### DIFF
--- a/lua/nvim-file-location/init.lua
+++ b/lua/nvim-file-location/init.lua
@@ -45,7 +45,6 @@ end
 -- @param add_column boolean
 -- @return nil
 function FileLocation.copy_file_location(mode, add_line, add_column)
-  print(mode)
   -- add defaults for optional parameters
   mode = (mode == nil and global_config.mode) or mode
   add_line = (add_line == nil and global_config.add_line) or add_line


### PR DESCRIPTION
After following the README's instructions and enabling the integration with `nvim-notify`, I noticed `nil` was being printed as a message every time I used the plugin. I tracked it down to def8b65a adding what I would presume to be a debug log for the mode of copying. It confused me initially as a user of the plugin, wondering what was supposed to be printed when I already had the notification.

I don't think it needs to be printed by default given that we already notify the user of the event. They'll be able to tell if the path copied is absolute or relative to the working directory.

I could see the print statement only occurring based on a set log level though, similar to what the `log` utility from `plenary.nvim` does.